### PR TITLE
Update Diagnostic and TypeName

### DIFF
--- a/lib-module/types/models/diagnostic.d.ts
+++ b/lib-module/types/models/diagnostic.d.ts
@@ -37,7 +37,7 @@ export interface Diagnostic extends Entity {
 	faultResetMode: FaultResetMode
 	isReadOnly: boolean
 	name: string
-	source: Source
+	source: string
 	tamperingDiagnostics: number
 	unitOfMeasure: UnitOfMeasure
 	version: string

--- a/lib-module/types/models/typeName.d.ts
+++ b/lib-module/types/models/typeName.d.ts
@@ -1,4 +1,4 @@
-export type TypeNamesNotTyped = 
+export type TypeNamesNotTyped =
   | "Annotation"
   | "Audit"
   | "Certificate"
@@ -30,6 +30,7 @@ export type TypeName =
   | "Annotation"
   | "Audit"
   | "Certificate"
+  | "Controller"
   | "Device"
   | "DeviceStatusInfo"
   | "Diagnostic"
@@ -38,6 +39,7 @@ export type TypeName =
   | "DutyStatusLog"
   | "DVIRLog"
   | "ExceptionEvent"
+  | "FailureMode"
   | "FaultData"
   | "FillUp"
   | "FuelTaxDetail"


### PR DESCRIPTION
- Updates Diagnostic. When a get call is made for Diagnostic, the source field is a string and not an object so I updated this accordingly.
- Updates TypeName so that Get calls can be made for Controller and FailureMode